### PR TITLE
Fix regex in DataFrame sentence cleaning

### DIFF
--- a/Week_05_Natural_Language_Processing.ipynb
+++ b/Week_05_Natural_Language_Processing.ipynb
@@ -2240,7 +2240,7 @@
       },
       "source": [
         "# This regular expression only keeps words and characters\n",
-        "df['sentence'] = df['sentence'].str.replace('[^\\w\\s]','')\n",
+        "df['sentence'] = df['sentence'].str.replace(r'[^\\w\\s]','',regex=True)\n",
         "df.head()"
       ],
       "execution_count": 13,


### PR DESCRIPTION
Earlier this step was not working. You have to explicitly add 'regex=True' to update the pandas dataframes using regexes

Before:
<img width="870" height="271" alt="image" src="https://github.com/user-attachments/assets/227f27f3-3737-4391-ae56-f43c74cf66de" />

Now:
<img width="706" height="262" alt="image" src="https://github.com/user-attachments/assets/92387bdf-a002-4350-af75-d6a353e35db0" />
